### PR TITLE
Fixes #3

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -23,7 +23,7 @@ which are implemented in different languages:
 
 3. Java
   - The distributed backbone infrastructure comprising:
-     - a central *Server* handing out subproblem specification to
+     - a central *Server* handling out subproblem specification to
      - distributed *Client*s relaying them to their locally attached
        FPGA devices.
   - A standalone *LocalMain* to serve local FPGAs from a local database

--- a/src/cpp/DBEntry.hpp
+++ b/src/cpp/DBEntry.hpp
@@ -31,7 +31,7 @@ namespace queens {
 
  /**
   * Thin wrapper class for accessing a database entry. It enables a more
-  * comfortable access to the binary entry layout, wich comprises two
+  * comfortable access to the binary entry layout, which comprises two
   * 64-bit words stored in network byte order (big endian):
   *
   *
@@ -69,7 +69,7 @@ namespace queens {
   * zero in this case. Otherwise, a DBEntry just provides the interpretation
   * for the two adjacent underlying 64-bit words of a memory-mapped database.
   * The corresponding objects are not really constructed but rather obtained
-  * by reinterpreting the pointer to the backing memory, e.g. thorugh an
+  * by reinterpreting the pointer to the backing memory, e.g. through an
   * reinterprete_cast<DBEntry*>(ptr).
   */
   class DBEntry {

--- a/src/cpp/q27db.cpp
+++ b/src/cpp/q27db.cpp
@@ -283,7 +283,7 @@ namespace {
       DBConstRange         range(dbx.roRange());
       DBEntry const *const beg = range.begin();
 
-      { // Parse range restictions
+      { // Parse range restrictions
 	RangeParser  parser;
 	for(int  i = 0; i < argc; i++) {
 	  try {

--- a/src/vhdl/PoC/common/physical.vhdl
+++ b/src/vhdl/PoC/common/physical.vhdl
@@ -853,7 +853,7 @@ package body physical is
 
 	-- calculate needed counter cycles to achieve a given 1. timing/delay and 2. frequency/period
 	-- ===========================================================================
-	--	@param Timing					A given timing or delay, which should be achived
+	--	@param Timing					A given timing or delay, which should be archived
 	--	@param Clock_Period		The period of the circuits clock
 	--	@RoundingStyle				Default = round to nearest; other choises: ROUND_UP, ROUND_DOWN
 	function TimingToCycles(Timing : time; Clock_Period : time; RoundingStyle : T_ROUNDING_STYLE := ROUND_UP) return natural is

--- a/src/vhdl/PoC/common/strings.vhdl
+++ b/src/vhdl/PoC/common/strings.vhdl
@@ -667,7 +667,7 @@ package body strings is
 		if (str'length > 0) then
 			-- WORKAROUND: for Altera Quartus-II
 			--	Version:	15.0
-			--	Issue:		array bounds are check regardless of the hierachy and control flow
+			--	Issue:		array bounds are check regardless of the hierarchy and control flow
 			Result(1 to imin(Size, imax(1, str'length))) := ite((str'length > 0), str(1 to imin(Size, str'length)), ConstNUL);
 		end if;
 		return Result;
@@ -729,7 +729,7 @@ package body strings is
 	end function;
 
 	-- compare two STRINGs for equality
-	-- pre-check the string lengthes to suppress warnings for unqual sized string comparisions.
+	-- pre-check the string lengths to suppress warnings for unequal sized string comparisons.
 	-- QUESTION: overload "=" operator?
 	function str_equal(str1 : string; str2 : string) return boolean is
 	begin

--- a/src/vhdl/PoC/common/vectors.vhdl
+++ b/src/vhdl/PoC/common/vectors.vhdl
@@ -84,8 +84,8 @@ package vectors is
 	--		myMatrix'range(2) returns always myMatrix'range(1);	see work-around notes below
 	--
 	-- USAGE NOTES:
-	--	dimmension 1 => rows			- e.g. Words
-	--	dimmension 2 => columns		- e.g. Bits/Bytes in a word
+	--	dimension 1 => rows			- e.g. Words
+	--	dimension 2 => columns		- e.g. Bits/Bytes in a word
 	--
 	-- WORKAROUND: for Xilinx ISE/iSim
 	--	Version:	14.2
@@ -776,7 +776,7 @@ package body vectors is
 	function to_slm(slvv : T_SLVV_8) return T_SLM is
 --		variable test		: STD_LOGIC_VECTOR(T_SLV_8'range);
 --		variable slm		: T_SLM(slvv'range, test'range);				-- BUG: iSIM 14.5 cascaded 'range accesses let iSIM break down
---		variable slm		: T_SLM(slvv'range, T_SLV_8'range);			-- BUG: iSIM 14.5 allocates 9 bits in dimmension 2
+--		variable slm		: T_SLM(slvv'range, T_SLV_8'range);			-- BUG: iSIM 14.5 allocates 9 bits in dimension 2
 		variable slm		: T_SLM(slvv'range, 7 downto 0);					-- WORKAROUND: use constant range
 	begin
 --		report "slvv:    slvv.length=" & INTEGER'image(slvv'length) &			"  slm.dim0.length=" & INTEGER'image(slm'length(1)) & "  slm.dim1.length=" & INTEGER'image(slm'length(2)) severity NOTE;

--- a/src/vhdl/PoC/fifo/fifo_cc_got_tempput.vhdl
+++ b/src/vhdl/PoC/fifo/fifo_cc_got_tempput.vhdl
@@ -128,7 +128,7 @@ architecture rtl of fifo_cc_got_tempput is
   signal IP1 : unsigned(A_BITS-1 downto 0);
   signal OP1 : unsigned(A_BITS-1 downto 0);
 
-  -- Commited Write Pointer (Commit Marker)
+  -- Committed Write Pointer (Commit Marker)
   signal IPm : unsigned(A_BITS-1 downto 0) := (others => '0');
 
   -----------------------------------------------------------------------------

--- a/src/vhdl/PoC/sync/sync_Bits.vhdl
+++ b/src/vhdl/PoC/sync/sync_Bits.vhdl
@@ -13,7 +13,7 @@
 --		clock-domain 'Clock'. The clock-domain boundary crossing is done by two
 --		synchronizer D-FFs. All bits are independent from each other. If a known
 --		vendor like Altera or Xilinx are recognized, a vendor specific
---		implementation is choosen.
+--		implementation is chosen.
 --
 --		ATTENTION:
 --			Use this synchronizer only for long time stable signals (flags).

--- a/src/vhdl/queens/expand_blocking.vhdl
+++ b/src/vhdl/queens/expand_blocking.vhdl
@@ -51,7 +51,7 @@ architecture rtl of expand_blocking is
   constant M : positive := log2ceil(N);
 
   -- Decoded Placement
-  -- Frame Indeces: 0 - west, 1 - north, 2 - east, 3 - south
+  -- Frame Indices: 0 - west, 1 - north, 2 - east, 3 - south
   subtype tRow   is std_logic_vector(0 to N-1);
   type    tEdge  is array(0 to L-1) of tRow;
   type    tFrame is array(0 to   3) of tEdge;

--- a/src/vhdl/top/dnk7_f5/dini/fifo/fifo_async_blk_reg.v
+++ b/src/vhdl/top/dnk7_f5/dini/fifo/fifo_async_blk_reg.v
@@ -5,7 +5,7 @@
 //
 //   A modification to the BLKRAM FIFO so that the input data/control, and
 // output data/control are registered before going to the BLKRAM.  This is
-// to make timing closure easier.  
+// to make timing closure easier.
 //
 //   This module should NOT be used in places where latency is important.
 //
@@ -87,7 +87,7 @@
 // Added optional clobbering of output data when not reading (simulation only).
 //
 // Revision 1.2  2012/11/26 16:54:21  neal
-// Fixed up some status output ports to make them more useable in some conditions.
+// Fixed up some status output ports to make them more usable in some conditions.
 //
 // Revision 1.1  2012/06/05 02:59:29  neal
 // Added a pipelined FIFO.
@@ -227,14 +227,14 @@ generate
   		.GEN_WRALMOSTFULL(GEN_WRALMOSTFULL)
 		) i_sel_fifo (
   		.reset(reset),
-		
+
   		.wr_clk(wr_clk),
   		.wr_en(INPUT_REG ? wr_en_d : wr_en),
   		.wr_din(wr_din_checksum), //.wr_din(INPUT_REG ? wr_din_d : wr_din),
   		.wr_full(wr_full_preclobber),
   		.wr_almostfull(wr_almostfull),
   		.wr_full_count(wr_full_count_selram),
-		
+
   		.rd_clk(rd_clk),
   		.rd_en(wr_en_blkram),
   		.rd_dout(wr_din_blkram),
@@ -343,7 +343,7 @@ always @(posedge rd_clk /*or posedge reset_rdclk*/) begin
 		ff_rd_empty <= 1'b1;
 		reg_rd_dout <= 'b0; // output FF from registered FIFO
 		ff_rd_dout <= 'b0; // secondary FF between FIFO and output FF
-	end else 
+	end else
 			*/
 	begin
 		if ((ff_rd_empty==1'b1) && (OUTPUT_REG==1)) begin

--- a/src/vhdl/top/dnk7_f5/dnk7_queens0.vhdl
+++ b/src/vhdl/top/dnk7_f5/dnk7_queens0.vhdl
@@ -84,7 +84,7 @@ architecture rtl of dnk7_queens0 is
   ----------------------------------------------------------------------------
   -- Communication Addresses
 
-  -- Word Adress: Read                          Write
+  -- Word Address: Read                          Write
   -----------------------------------------------------------------------------
   -- 0x0000       <byte capacity:32>            <-:30><enable:2> input  interrupt
   -- 0x0004       <bytes available:32>          <-:30><enable:2> output interrupt
@@ -136,7 +136,7 @@ architecture rtl of dnk7_queens0 is
       dcm_psclk    : in  std_logic;
       dcm_psen     : in  std_logic;
       dcm_psincdec : in  std_logic;
-      
+
       target_address       : out std_logic_vector(63 downto 0);
       target_write_data    : out std_logic_vector(63 downto 0);
       target_write_be      : out std_logic_vector(7 downto 0);
@@ -442,7 +442,7 @@ begin
       target_read_data       <= rdDat;
       target_read_data_tag   <= rdTag;
       target_read_data_ctrl  <= rdCtl;
-      
+
     end block blkRead;
 
     ---------------------------------------------------------------------------
@@ -633,7 +633,7 @@ begin
     begin
 
       -------------------------------------------------------------------------
-      -- Ouput Inverted Clock
+      -- Output Inverted Clock
       blkClock : block
         signal clk_inv : std_logic;
       begin
@@ -666,8 +666,8 @@ begin
       end block blkClock;
 
       -------------------------------------------------------------------------
-      -- Pre-placement Ouput
-      
+      -- Pre-placement Output
+
       -- Syncing stall input
       process(clk_slow)
       begin
@@ -680,7 +680,7 @@ begin
         end if;
       end process;
       pigot <= avld and not stall_s(0);
-      
+
       -- Output Registers
       process(clk_slow)
       begin
@@ -766,7 +766,7 @@ begin
         );
       rst_in <= '0';
     end block blkClock;
-    
+
     -- Bus Input Capture
     process(clk_in)
     begin
@@ -867,7 +867,7 @@ begin
         soeof => soeof,
         sogot => sogot
       );
-    
+
       enframe_i: entity work.enframe
         generic map (
           SENTINEL => SENTINEL

--- a/src/vhdl/top/dnk7_f5/dnk7_queens1.vhdl
+++ b/src/vhdl/top/dnk7_f5/dnk7_queens1.vhdl
@@ -344,7 +344,7 @@ begin
   blkOutput : block
   begin
     -------------------------------------------------------------------------
-    -- Ouput Inverted Clock
+    -- Output Inverted Clock
     blkClock : block
       signal clk_inv : std_logic;
     begin
@@ -385,13 +385,13 @@ begin
       signal pgot : std_logic;
       signal pdat : std_logic_vector(8 downto 0);
       signal pvld : std_logic;
-      
+
       -- Outgoing Output Registers
       signal PreOutDat : std_logic_vector(8 downto 0) := (others => '0');
       signal PreOutPut : std_logic := '0';
 
     begin
-    
+
       -- Syncing stall input
       process(clk_out)
       begin
@@ -403,7 +403,7 @@ begin
           end if;
         end if;
       end process;
-      
+
       -- Output FIFO (ic): Pre-Placements
       fifob : fifo_ic_got
         generic map (

--- a/src/vhdl/top/xilinx/sdrc_queens_master.vhdl
+++ b/src/vhdl/top/xilinx/sdrc_queens_master.vhdl
@@ -18,7 +18,7 @@ entity sdrc_queens_master is
     CLK_MUL  : positive := 31;		-- computation clock:
     CLK_DIV  : positive :=  4;		--    CLK_FREQ / CLK_DIV * CLK_MUL
 
-    -- UART Parametes
+    -- UART Parameters
     BAUDRATE : positive := 115200;
     SENTINEL : std_logic_vector(7 downto 0) := x"FA"  -- Start Byte
   );
@@ -327,7 +327,7 @@ begin
   begin
 
     -------------------------------------------------------------------------
-    -- Ouput Inverted Clock
+    -- Output Inverted Clock
     blkClock : block
       signal clk_inv : std_logic;
     begin
@@ -360,8 +360,8 @@ begin
     end block blkClock;
 
     -------------------------------------------------------------------------
-    -- Pre-placement Ouput
-    
+    -- Pre-placement Output
+
     -- Syncing stall input
     process(clk_out)
     begin
@@ -464,7 +464,7 @@ begin
         );
       rst_in <= '0';
     end block blkClock;
-    
+
     -- Bus Input Capture
     process(clk_in)
     begin

--- a/src/vhdl/top/xilinx/sdrc_queens_slave.vhdl
+++ b/src/vhdl/top/xilinx/sdrc_queens_slave.vhdl
@@ -355,7 +355,7 @@ begin
   blkOutput : block
   begin
     -------------------------------------------------------------------------
-    -- Ouput Inverted Clock
+    -- Output Inverted Clock
     blkClock : block
       signal clk_inv : std_logic;
     begin
@@ -396,13 +396,13 @@ begin
       signal pgot : std_logic;
       signal pdat : std_logic_vector(8 downto 0);
       signal pvld : std_logic;
-      
+
       -- Outgoing Output Registers
       signal PreOutDat : std_logic_vector(8 downto 0) := (others => '0');
       signal PreOutPut : std_logic := '0';
 
     begin
-    
+
       -- Syncing go input
       process(clk_out)
       begin
@@ -414,7 +414,7 @@ begin
           end if;
         end if;
       end process;
-      
+
       -- Output FIFO (ic): Pre-Placements
       fifob : fifo_ic_got
         generic map (


### PR DESCRIPTION
Fixes the typos described in #3 except as noted:
- [x] q27/src/README.md:26: handing  ==> handling
- [x] q27/src/cpp/DBEntry.hpp:34: wich  ==> which  | witch
- [x] q27/src/cpp/DBEntry.hpp:72: thorugh  ==> through
- [x] q27/src/cpp/q27db.cpp:286: restictions  ==> restrictions
- [x] q27/src/java/me/preusser/q27/DiniSolver.java:33: Polynom  ==>
  Polynomial **Appears to be an intentional abbreviation**
- [x] q27/src/java/me/preusser/q27/UartSolver.java:42: Polynom  ==>
  Polynomial **Appears to be an intentional abbreviation**
- [x] q27/src/dini/DiniBoard.cpp:20: klass  ==> class **Seems
  intentional to prevent collision with "Class" C++ Reserved Word**
- [x] q27/src/dini/DiniBoard.cpp:31: klass  ==> class **Seems
  intentional to prevent collision with "Class" C++ Reserved Word**
- [x] q27/src/dini/DiniBoard.cpp:42: klass  ==> class **Seems
  intentional to prevent collision with "Class" C++ Reserved Word**
- [x] q27/src/vhdl/PoC/common/vectors.vhdl:87: dimmension  ==> dimension
- [x] q27/src/vhdl/PoC/common/vectors.vhdl:88: dimmension  ==> dimension
- [x] q27/src/vhdl/PoC/common/vectors.vhdl:779: dimmension  ==>
  dimension
- [x] q27/src/vhdl/PoC/common/strings.vhdl:670: hierachy  ==> hierarchy
- [x] q27/src/vhdl/PoC/common/strings.vhdl:732: comparisions  ==>
  comparisons **Also corrected 'lengthes' to 'lengths' and 'unqual' to
  'unequal'**
- [x] q27/src/vhdl/PoC/common/physical.vhdl:856: achived  ==> archived
- [x] q27/src/vhdl/PoC/fifo/fifo_cc_got_tempput.vhdl:131: Commited  ==>
  Committed
- [x] q27/src/vhdl/PoC/sync/sync_Bits.vhdl:16: choosen  ==> chosen
- [x] q27/src/vhdl/queens/expand_blocking.vhdl:54: Indeces  ==> Indexes
  **Indices**
- [x] q27/src/vhdl/top/dnk7_f5/dnk7_queens1.vhdl:347: Ouput  ==> Output
- [x] q27/src/vhdl/top/dnk7_f5/dnk7_queens0.vhdl:87: Adress  ==> Address
- [x] q27/src/vhdl/top/dnk7_f5/dnk7_queens0.vhdl:636: Ouput  ==> Output
- [x] q27/src/vhdl/top/dnk7_f5/dnk7_queens0.vhdl:669: Ouput  ==> Output
- [x] q27/src/vhdl/top/dnk7_f5/dini/fifo/fifo_checksum.v:43: dont  ==>
  don't, do not **Variable name. Apostrophe will cause issues**
- [x] q27/src/vhdl/top/dnk7_f5/dini/fifo/fifo_addr.v:319: dont  ==>
  don't, do not **Variable name. Apostrophe will cause issues**
- [x] q27/src/vhdl/top/dnk7_f5/dini/fifo/fifo_async_blk_reg.v:90:
  useable  ==> usable
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  39: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  40: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  41: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  42: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  43: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  44: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  45: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x]
  q27/src/vhdl/top/dnk7_f5/dini/pcie/pcie_dma/user_fpga/pcie_interface.v:5
  46: dont  ==> don't, do not **Variable name. Apostrophe will cause
  issues**
- [x] q27/src/vhdl/top/xilinx/sdrc_queens_master.vhdl:21: Parametes
  ==> Parameters
- [x] q27/src/vhdl/top/xilinx/sdrc_queens_master.vhdl:330: Ouput  ==>
  Output
- [x] q27/src/vhdl/top/xilinx/sdrc_queens_master.vhdl:363: Ouput  ==>
  Output
- [x] q27/src/vhdl/top/xilinx/sdrc_queens_slave.vhdl:358: Ouput  ==>
  Output
